### PR TITLE
Windows Support

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -22,7 +22,7 @@
           "./src/win/i2c.cc",
           "./src/win/i2c.h" 
         ],
-        'msvs_windows_target_platform_version': 'v10.0',
+        'msvs_windows_sdk_version': 'v10.0',
         'win_delay_load_hook': 'false',
         'msvs_onecore_vcpp_libs': 1,
         'msvs_settings': {

--- a/binding.gyp
+++ b/binding.gyp
@@ -19,6 +19,9 @@
       }],
       ["OS == \"win\"", {
         "sources": [
+          "./src/win/readPartial.cc",
+          "./src/win/writePartial.cc",
+          "./src/win/writeReadPartial.cc",
           "./src/win/i2c.cc",
           "./src/win/i2c.h" 
         ],

--- a/binding.gyp
+++ b/binding.gyp
@@ -11,8 +11,60 @@
     "include_dirs" : [
       "<!(node -e \"require('nan')\")"
     ],
-    "sources": [
-      "./src/i2c.cc"
+    "conditions": [
+      ["OS == \"linux\"", {
+        "sources": [
+         "./src/i2c.cc"
+        ]
+      }],
+      ["OS == \"win\"", {
+        "sources": [
+          "./src/win/i2c.cc",
+          "./src/win/i2c.h" 
+        ],
+        'msvs_windows_target_platform_version': 'v10.0',
+        'win_delay_load_hook': 'false',
+        'msvs_onecore_vcpp_libs': 1,
+        'msvs_settings': {
+          'VCLinkerTool': {
+            'IgnoreDefaultLibraryNames' : ['kernel32.lib','advapi32.lib', 'ole32.lib' ],
+            'conditions': [
+            [ 'target_arch=="ia32"', {
+              'AdditionalLibraryDirectories' : [ '$(VCInstallDir)lib\onecore;$(WindowsSDK_LibraryPath_x86);$(UniversalCRT_LibraryPath_x86)' ],
+            } ],
+            [ 'target_arch=="x64"', {
+              'AdditionalLibraryDirectories' : [ '$(VCInstallDir)lib\onecore\\amd64;$(WindowsSDK_LibraryPath_x64);$(UniversalCRT_LibraryPath_x64)' ],
+            } ],
+            [ 'target_arch=="arm"', {
+              'AdditionalLibraryDirectories' : [ '$(VCInstallDir)lib\onecore\\arm;$(WindowsSDK_LibraryPath_arm);$(UniversalCRT_LibraryPath_arm)' ],
+            } ],
+          ],
+          },
+          'VCCLCompilerTool': {
+            'AdditionalUsingDirectories': [ '$(VCInstallDir)vcpackages;$(WindowsSdkDir)UnionMetadata;%(AdditionalUsingDirectories)' ],
+            'CompileAsWinRT': 'true',
+          }
+        },
+        'libraries': [
+          '-lonecore.lib',
+        ],
+        'configurations': {
+          'Release': {
+            'msvs_settings': {
+              'VCCLCompilerTool': {
+                'RuntimeLibrary': '2',
+             }
+            },
+          },
+          'Debug': {
+            'msvs_settings': {
+              'VCCLCompilerTool': {
+                'RuntimeLibrary': '3',
+              }
+            },
+          }
+        }       
+      }]
     ]
   }]
 }

--- a/example/MCP9808-async.js
+++ b/example/MCP9808-async.js
@@ -1,0 +1,131 @@
+// The code below is based on the Adafruit MCP9808 library (https://github.com/adafruit/Adafruit_MCP9808_Library)
+
+'use strict';
+
+var I2C_CONTROLLER_NAME = 'I2C1'; // Specific to RPi2 with Windows 10 IoT Core
+
+var async = require('async'),
+  i2c = require('i2c-bus'),
+  i2c1;
+
+var MCP9808_I2CADDR_DEFAULT = 0x18,
+  MCP9808_REG_CONFIG = 0x01,
+  MCP9808_REG_AMBIENT_TEMP = 0x05,
+  MCP9808_REG_CONFIG_SHUTDOWN = 0x0100;
+
+var BUFFER_SIZE = 2;
+
+function shutdown_wake(sw_ID, callback) {
+  var conf_shutdown;
+  const buffer = new Buffer(BUFFER_SIZE);
+
+  async.series([
+    function (cb) {
+      i2c1.readI2cBlock(MCP9808_I2CADDR_DEFAULT, MCP9808_REG_CONFIG, BUFFER_SIZE, buffer, function (err, conf_register) {
+        if (err) {
+          throw err;
+        }
+
+        if (sw_ID == 1) {
+          conf_shutdown = conf_register | MCP9808_REG_CONFIG_SHUTDOWN;
+        }
+        if (sw_ID == 0) {
+          conf_shutdown = conf_register ^ MCP9808_REG_CONFIG_SHUTDOWN;
+        }
+        cb(null);
+      });
+    },
+    function (cb) {
+      i2c1.i2cWrite(MCP9808_I2CADDR_DEFAULT, 2, new Buffer([MCP9808_REG_CONFIG, conf_shutdown]), function (err, bytesWrittern) {
+        if (err) {
+          throw err;
+        }
+
+        cb(null);
+      });
+    },
+  ], function (err) {
+    if (err) {
+      throw err;
+    }
+
+    callback(null);
+  });
+}
+
+function readTempC(callback) {
+  const buffer = new Buffer(BUFFER_SIZE);
+  var t;
+  var temp;
+
+  async.series([
+    function (cb) {
+      i2c1.readI2cBlock(MCP9808_I2CADDR_DEFAULT, MCP9808_REG_AMBIENT_TEMP, BUFFER_SIZE, buffer, function (err, result) {
+        if (err) {
+          throw err;
+        }
+
+        t = result;
+        cb(null);
+      });
+    },
+    function (cb) {
+      t = buffer[0];
+      t <<= 8;
+      t |= buffer[1];
+
+      temp = t & 0x0FFF;
+      temp /= 16.0;
+      if (t & 0x1000) temp -= 256;
+      cb(null, temp);
+    },
+  ], function (err, results) {
+    if (err) {
+      throw err;
+    }
+
+    callback(results[1]);
+    return temp;
+  });
+}
+
+
+(function () {
+  var rawTemp;
+  var c;
+
+  async.series([
+    function (cb) {
+      i2c1 = i2c.open(I2C_CONTROLLER_NAME, cb);
+    },
+    function (cb) {
+      console.log("wake up MCP9808.... ");
+      shutdown_wake(0, function () {
+        cb(null);
+      });
+    },
+    function (cb) {
+      readTempC(function (temp) {
+        c = temp;
+        cb(null);
+      });
+    },
+    function (cb) {
+      var f = c * 9.0 / 5.0 + 32;
+      console.log("Temp: " + c + "*C");
+      console.log("Temp: " + f + "*F");
+      cb(null);
+    },
+    function (cb) {
+      setTimeout(function () {
+        console.log("Shutdown MCP9808.... ");
+        shutdown_wake(1);
+        i2c1.close();
+      }, 250);
+    },
+  ], function (err) {
+    if (err) {
+      throw err;
+    }
+  });
+}());

--- a/example/MCP9808-async.js
+++ b/example/MCP9808-async.js
@@ -119,9 +119,13 @@ function readTempC(callback) {
     function (cb) {
       setTimeout(function () {
         console.log("Shutdown MCP9808.... ");
-        shutdown_wake(1);
-        i2c1.close();
+        shutdown_wake(1, function () {
+          cb(null);
+        });
       }, 250);
+    },
+    function (cb) {
+      i2c1.close(cb);
     },
   ], function (err) {
     if (err) {

--- a/example/MCP9808-sync.js
+++ b/example/MCP9808-sync.js
@@ -1,0 +1,61 @@
+// The code below is based on the Adafruit MCP9808 library (https://github.com/adafruit/Adafruit_MCP9808_Library)
+
+var I2C_CONTROLLER_NAME = 'I2C1'; // Specific to RPi2 with Windows 10 IoT Core
+
+var i2c = require('i2c-bus'),
+  i2c1 = i2c.openSync(I2C_CONTROLLER_NAME);
+
+var MCP9808_I2CADDR_DEFAULT = 0x18,
+  MCP9808_REG_CONFIG = 0x01,
+  MCP9808_REG_AMBIENT_TEMP = 0x05,
+  MCP9808_REG_CONFIG_SHUTDOWN = 0x0100;
+
+var BUFFER_SIZE = 2;
+
+function shutdown_wake(sw_ID) {
+  var conf_shutdown;
+  const buffer = new Buffer(BUFFER_SIZE);
+  var conf_register = i2c1.readI2cBlockSync(MCP9808_I2CADDR_DEFAULT, MCP9808_REG_CONFIG, BUFFER_SIZE, buffer);
+  if (sw_ID == 1) {
+    conf_shutdown = conf_register | MCP9808_REG_CONFIG_SHUTDOWN;
+    i2c1.i2cWriteSync(MCP9808_I2CADDR_DEFAULT, 2, new Buffer([MCP9808_REG_CONFIG, conf_shutdown]));
+  }
+  if (sw_ID == 0) {
+    conf_shutdown = conf_register ^ MCP9808_REG_CONFIG_SHUTDOWN;
+    i2c1.i2cWriteSync(MCP9808_I2CADDR_DEFAULT, 2, new Buffer([MCP9808_REG_CONFIG, conf_shutdown]));
+  }
+}
+
+function readTempC() {
+  const buffer = new Buffer(BUFFER_SIZE);
+  
+  var t = i2c1.readI2cBlockSync(MCP9808_I2CADDR_DEFAULT, MCP9808_REG_AMBIENT_TEMP, BUFFER_SIZE, buffer);
+  t = buffer[0];
+  t <<= 8;
+  t |= buffer[1];
+  
+  var temp = t & 0x0FFF;
+  temp /=  16.0;
+  if (t & 0x1000) temp -= 256;
+
+  return temp;
+}
+
+(function () {
+  var rawTemp;
+
+  console.log("wake up MCP9808.... ");
+  shutdown_wake(0);
+
+  var c = readTempC();
+  var f = c * 9.0 / 5.0 + 32;
+  console.log("Temp: " + c + "*C");
+  console.log("Temp: " + f + "*F");
+
+  setTimeout(function() {
+    console.log("Shutdown MCP9808.... ");
+    shutdown_wake(1);
+
+    i2c1.closeSync();
+  }, 250);
+}());

--- a/i2c-bus.js
+++ b/i2c-bus.js
@@ -398,3 +398,7 @@ Bus.prototype.scanSync = function () {
   return addresses;
 };
 
+if ("win32" == process.platform) {
+  Bus = require('./win-i2c-bus.js').Bus;
+}
+

--- a/src/win/i2c.cc
+++ b/src/win/i2c.cc
@@ -1,0 +1,318 @@
+#include "i2c.h"
+#include <ppltasks.h>
+#include <vector>
+#include <iostream>
+
+using v8::FunctionTemplate;
+using namespace concurrency;
+using namespace Platform;
+using namespace Windows::Devices::Enumeration;
+
+Nan::Persistent<v8::Function> WinI2c::constructor;
+
+NAN_MODULE_INIT(WinI2c::Init) {
+  v8::Local<v8::FunctionTemplate> tpl = Nan::New<v8::FunctionTemplate>(New);
+  tpl->SetClassName(Nan::New("WinI2c").ToLocalChecked());
+  tpl->InstanceTemplate()->SetInternalFieldCount(6);
+
+  Nan::SetPrototypeMethod(tpl, "openSync", OpenSync);
+  Nan::SetPrototypeMethod(tpl, "closeSync", CloseSync);
+  Nan::SetPrototypeMethod(tpl, "read", Read);
+  Nan::SetPrototypeMethod(tpl, "readPartial", ReadPartial);
+  Nan::SetPrototypeMethod(tpl, "write", Write);
+  Nan::SetPrototypeMethod(tpl, "writePartial", WritePartial);
+  Nan::SetPrototypeMethod(tpl, "writeRead", WriteRead);
+  Nan::SetPrototypeMethod(tpl, "writeReadPartial", WriteReadPartial);
+  Nan::SetPrototypeMethod(tpl, "setDevice", SetDevice);
+
+  constructor.Reset(Nan::GetFunction(tpl).ToLocalChecked());
+  Nan::Set(target, Nan::New("WinI2c").ToLocalChecked(), Nan::GetFunction(tpl).ToLocalChecked());
+}
+
+WinI2c::WinI2c() {
+  RoInitialize(RO_INIT_MULTITHREADED);
+}
+
+WinI2c::~WinI2c() {
+  RoUninitialize();
+}
+
+NAN_METHOD(WinI2c::New) {
+  if (info.IsConstructCall()) {
+    WinI2c *obj = new WinI2c();
+    obj->Wrap(info.This());
+    info.GetReturnValue().Set(info.This());
+  }
+  else {
+    const int argc = 1;
+    v8::Local<v8::Value> argv[argc] = { info[0] };
+    v8::Local<v8::Function> cons = Nan::New(constructor);
+    info.GetReturnValue().Set(cons->NewInstance(argc, argv));
+  }
+}
+
+NAN_METHOD(WinI2c::OpenSync) {
+  if (info.Length() < 1 ||
+      !info[0]->IsString()) {
+    return Nan::ThrowError(Nan::ErrnoException(EINVAL, "WinI2c::OpenSync",
+      "incorrect arguments passed to WinI2c::OpenSync"
+      "(string i2cControllerName)"));
+  }
+
+  Nan::HandleScope scope;
+  v8::String::Utf8Value str(info[0]->ToString());
+  std::string stdStr = std::string(*str);
+  std::wstring stdWStr;
+  stdWStr.assign(stdStr.begin(), stdStr.end());
+
+  String^ deviceSelector = I2cDevice::GetDeviceSelector(ref new Platform::String(stdWStr.c_str()));
+  DeviceInformationCollection^ i2cDeviceControllers = create_task(DeviceInformation::FindAllAsync(deviceSelector)).get();
+
+  if (nullptr == i2cDeviceControllers) {
+    Nan::ThrowError(Nan::ErrnoException(EPERM, "WinI2c::OpenSync", "DeviceInformation::FindAllAsync failed to return controller(s)"));
+  }
+
+  WinI2c* obj = Nan::ObjectWrap::Unwrap<WinI2c>(info.This());
+  obj->_i2cDeviceId = i2cDeviceControllers->GetAt(0)->Id;
+}
+
+NAN_METHOD(WinI2c::SetDevice) {
+  if (info.Length() < 1 ||
+      !info[0]->IsInt32()) {
+    return Nan::ThrowError(Nan::ErrnoException(EINVAL, "WinI2c::SetDevice",
+      "incorrect arguments passed to WinI2c::SetDevice"
+      "(int deviceAddress)"));
+  }
+
+  WinI2c* obj = Nan::ObjectWrap::Unwrap<WinI2c>(info.This());
+
+  if(nullptr == obj->_i2cDevice) {
+    I2cConnectionSettings^ settings = ref new I2cConnectionSettings(info[0]->Int32Value());
+    
+    //TODO: Expose as properties for the user to change
+    settings->BusSpeed = I2cBusSpeed::FastMode;
+    settings->SharingMode = I2cSharingMode::Exclusive;
+    
+    obj->_i2cDevice = create_task(I2cDevice::FromIdAsync(obj->_i2cDeviceId, settings)).get();
+    if (nullptr == obj->_i2cDevice) {
+      Nan::ThrowError(Nan::ErrnoException(EPERM, "WinI2c::SetDevice", "I2cDevice::FromIdAsync failed to return an i2c device"));
+    }
+  }
+}
+
+NAN_METHOD(WinI2c::CloseSync) {
+  WinI2c* obj = Nan::ObjectWrap::Unwrap<WinI2c>(info.This());
+
+  //From https://msdn.microsoft.com/en-us/library/windows.devices.i2c.i2cdevice.close.aspx
+  // You cannot call Close methods through Visual C++ component extensions(C++ / CX) on 
+  // Windows Runtime class instances where the class implemented IClosable.Instead, C++ / CX code 
+  // for runtime classes should call the destructor or set the last reference to null.
+  obj->_i2cDevice = nullptr;
+}
+
+NAN_METHOD(WinI2c::Read) {
+  Nan::ThrowError(Nan::ErrnoException(EPERM, "WinI2c::Read", "Not Implemented"));
+}
+
+NAN_METHOD(WinI2c::ReadPartial) {
+  if (info.Length() < 2 ||
+      !info[0]->IsInt32() ||
+      !info[1]->IsObject()) {
+    return Nan::ThrowError(Nan::ErrnoException(EINVAL, "WinI2c::ReadPartial",
+      "incorrect arguments passed to WinI2c::ReadPartial"
+      "(int length, Buffer buffer)"));
+  }
+
+  Nan::HandleScope scope;
+  uint32 length = info[0]->Uint32Value();
+  v8::Local<v8::Object> bufferHandle = info[1].As<v8::Object>();
+  int bytesRead = -1;
+  byte* bufferData = (byte*)node::Buffer::Data(bufferHandle);
+  size_t bufferLength = node::Buffer::Length(bufferHandle);
+
+  if (length > bufferLength) {
+    return Nan::ThrowError(Nan::ErrnoException(EINVAL, "WinI2c::ReadPartial",
+      "buffer passed to WinI2c::Read contains less than 'length' bytes"));
+  }
+
+  auto readBuf = ref new Platform::Array<BYTE>(length);
+  WinI2c* obj = Nan::ObjectWrap::Unwrap<WinI2c>(info.This());
+  try {
+    I2cTransferResult result = obj->_i2cDevice->ReadPartial(readBuf);
+
+    switch (result.Status) {
+      case I2cTransferStatus::FullTransfer:
+        bytesRead = result.BytesTransferred;
+        break;
+      case I2cTransferStatus::PartialTransfer:
+        bytesRead = result.BytesTransferred;
+        wprintf(L"%d bytes partially transferred\n", bytesRead);
+        break;
+      case I2cTransferStatus::SlaveAddressNotAcknowledged:
+        wprintf(L"Slave address was not acknowledged\n");
+        break;
+      default:
+        wprintf(L"Invalid transfer status value\n");
+    }
+  }
+  catch (Exception^ e) {
+    Nan::ThrowError(Nan::ErrnoException(e->HResult, "WinI2c::ReadPartial", ""));
+  }
+
+  for (int i = 0; i < readBuf->Length; i++) {
+    bufferData[i] = readBuf[i];
+  }
+
+  if (bytesRead == -1) {
+    return Nan::ThrowError(Nan::ErrnoException(errno, "WinI2c::ReadPartial", ""));
+  }
+
+  info.GetReturnValue().Set(Nan::New<v8::Integer>(bytesRead));
+}
+
+NAN_METHOD(WinI2c::Write) {
+  if (info.Length() < 1 || !info[0]->IsArray()) {
+    return Nan::ThrowError(Nan::ErrnoException(EINVAL, "WinI2c::Write",
+      "incorrect arguments passed to WinI2c::Write"));
+  }
+
+  Nan::HandleScope scope;
+  std::vector<BYTE> bytes;
+  v8::Handle<v8::Value> val;
+  v8::Local<v8::Array> arr = Nan::New<v8::Array>();
+
+  v8::Handle<v8::Array> jsArray = v8::Handle<v8::Array>::Cast(info[0]);
+  for (unsigned int i = 0; i < jsArray->Length(); i++) {
+    val = jsArray->Get(i);
+    bytes.push_back(static_cast<BYTE>(val->Uint32Value()));
+    Nan::Set(arr, i, val);
+  }
+
+  WinI2c* obj = Nan::ObjectWrap::Unwrap<WinI2c>(info.This());
+  try {
+    obj->_i2cDevice->Write(ArrayReference<BYTE>(bytes.data(), static_cast<unsigned int>(bytes.size())));
+  } catch (Exception^ e) {
+    Nan::ThrowError(Nan::ErrnoException(e->HResult, "WinI2c::Write", ""));
+  }
+}
+
+NAN_METHOD(WinI2c::WritePartial) {
+  if (info.Length() < 2 ||
+      !info[0]->IsInt32() ||
+      !info[1]->IsObject()) {
+    return Nan::ThrowError(Nan::ErrnoException(EINVAL, "WinI2c::WritePartial",
+      "incorrect arguments passed to WinI2c::WritePartial"
+      "(int length, Buffer buffer)"));
+  }
+  
+  Nan::HandleScope scope;
+  uint32 length = info[0]->Uint32Value();
+  v8::Local<v8::Object> bufferHandle = info[1].As<v8::Object>();
+  int bytesWritten = -1;
+  byte* bufferData = (byte*)node::Buffer::Data(bufferHandle);
+  size_t bufferLength = node::Buffer::Length(bufferHandle);
+
+  if (length > bufferLength) {
+    return Nan::ThrowError(Nan::ErrnoException(EINVAL, "WinI2c::WritePartial",
+      "buffer passed to WinI2c::WritePartial contains less than 'length' bytes"));
+  }
+
+  auto writeBuf = ref new Platform::Array<BYTE>(length);
+
+  for (int i = 0; i < writeBuf->Length; i++) {
+    writeBuf->set(i, bufferData[i]);
+  }
+
+  WinI2c* obj = Nan::ObjectWrap::Unwrap<WinI2c>(info.This());
+  try {
+    I2cTransferResult result = obj->_i2cDevice->WritePartial(writeBuf);
+    switch (result.Status) {
+      case I2cTransferStatus::FullTransfer:
+        bytesWritten = result.BytesTransferred;
+        break;
+      case I2cTransferStatus::PartialTransfer:
+        bytesWritten = result.BytesTransferred;
+        wprintf(L"%d bytes partially transferred\n", bytesWritten);
+        break;
+      case I2cTransferStatus::SlaveAddressNotAcknowledged:
+        wprintf(L"Slave address was not acknowledged\n");
+        break;
+      default:
+        wprintf(L"Invalid transfer status value\n");
+    }
+  }
+  catch (Exception^ e) {
+    Nan::ThrowError(Nan::ErrnoException(e->HResult, "WinI2c::WritePartial", ""));
+  }
+
+  if (bytesWritten == -1) {
+    return Nan::ThrowError(Nan::ErrnoException(errno, "WinI2c::WritePartial", ""));
+  }
+
+  info.GetReturnValue().Set(Nan::New<v8::Integer>(bytesWritten));
+}
+
+NAN_METHOD(WinI2c::WriteRead) {
+  Nan::ThrowError(Nan::ErrnoException(EPERM, "WinI2c::WriteRead", "Not Implemented"));
+}
+
+NAN_METHOD(WinI2c::WriteReadPartial) {
+  if (info.Length() < 3 ||
+      !info[0]->IsInt32() ||
+      !info[1]->IsInt32() ||
+      !info[2]->IsObject()) {
+    return Nan::ThrowError(Nan::ErrnoException(EINVAL, "WinI2c::WriteReadPartial",
+      "incorrect arguments passed to WinI2c::WriteReadPartial"
+      "(int cmd, int length, Buffer buffer)"));
+  }
+
+  Nan::HandleScope scope;
+  uint32 length = info[1]->Uint32Value();
+  v8::Local<v8::Object> bufferHandle = info[2].As<v8::Object>();
+  int bytesRead = -1;
+  byte* bufferData = (byte*)node::Buffer::Data(bufferHandle);
+  size_t bufferLength = node::Buffer::Length(bufferHandle);
+
+  if (length > bufferLength) {
+    return Nan::ThrowError(Nan::ErrnoException(EINVAL, "WinI2c::WriteReadPartial",
+      "buffer passed to WinI2c::WriteReadPartial contains less than 'length' bytes"));
+  }
+  
+  auto readBuf = ref new Platform::Array<BYTE>(length);
+  auto writeBuf = ref new Platform::Array<BYTE>(1);
+  writeBuf->set(0, info[0]->Int32Value());
+
+  WinI2c* obj = Nan::ObjectWrap::Unwrap<WinI2c>(info.This());
+  try {
+    I2cTransferResult result = obj->_i2cDevice->WriteReadPartial(writeBuf, readBuf);
+    switch (result.Status) {
+      case I2cTransferStatus::FullTransfer:
+        bytesRead = result.BytesTransferred;
+        break;
+      case I2cTransferStatus::PartialTransfer:
+        bytesRead = result.BytesTransferred;
+        wprintf(L"%d bytes partially transferred\n", bytesRead);
+        break;
+      case I2cTransferStatus::SlaveAddressNotAcknowledged:
+        wprintf(L"Slave address was not acknowledged\n");
+        break;
+      default:
+        wprintf(L"Invalid transfer status value\n");
+    }
+  }
+  catch (Exception^ e) {
+    Nan::ThrowError(Nan::ErrnoException(e->HResult, "WinI2c::WriteReadPartial", ""));
+  }
+
+  for (int i = 0; i < readBuf->Length; i++) {
+    bufferData[i] = readBuf[i];
+  }
+
+  if (bytesRead == -1) {
+    return Nan::ThrowError(Nan::ErrnoException(errno, "WinI2c::WriteReadPartial", ""));
+  }
+
+  info.GetReturnValue().Set(Nan::New<v8::Integer>(bytesRead));
+}
+
+NODE_MODULE(i2c, WinI2c::Init)

--- a/src/win/i2c.cc
+++ b/src/win/i2c.cc
@@ -59,7 +59,6 @@ NAN_METHOD(WinI2c::OpenSync) {
       "(string i2cControllerName)"));
   }
 
-  Nan::HandleScope scope;
   v8::String::Utf8Value str(info[0]->ToString());
   std::string stdStr = std::string(*str);
   std::wstring stdWStr;
@@ -69,7 +68,7 @@ NAN_METHOD(WinI2c::OpenSync) {
   DeviceInformationCollection^ i2cDeviceControllers = create_task(DeviceInformation::FindAllAsync(deviceSelector)).get();
 
   if (nullptr == i2cDeviceControllers) {
-    Nan::ThrowError(Nan::ErrnoException(EPERM, "WinI2c::OpenSync", "DeviceInformation::FindAllAsync failed to return controller(s)"));
+    return Nan::ThrowError(Nan::ErrnoException(EPERM, "WinI2c::OpenSync", "DeviceInformation::FindAllAsync failed to return controller(s)"));
   }
 
   WinI2c* obj = Nan::ObjectWrap::Unwrap<WinI2c>(info.This());
@@ -95,7 +94,7 @@ NAN_METHOD(WinI2c::SetDevice) {
     
     obj->_i2cDevice = create_task(I2cDevice::FromIdAsync(obj->_i2cDeviceId, settings)).get();
     if (nullptr == obj->_i2cDevice) {
-      Nan::ThrowError(Nan::ErrnoException(EPERM, "WinI2c::SetDevice", "I2cDevice::FromIdAsync failed to return an i2c device"));
+      return Nan::ThrowError(Nan::ErrnoException(EPERM, "WinI2c::SetDevice", "I2cDevice::FromIdAsync failed to return an i2c device"));
     }
   }
 }
@@ -111,7 +110,7 @@ NAN_METHOD(WinI2c::CloseSync) {
 }
 
 NAN_METHOD(WinI2c::Read) {
-  Nan::ThrowError(Nan::ErrnoException(EPERM, "WinI2c::Read", "Not Implemented"));
+  return Nan::ThrowError(Nan::ErrnoException(EPERM, "WinI2c::Read", "Not Implemented"));
 }
 
 NAN_METHOD(WinI2c::ReadPartial) {
@@ -123,7 +122,6 @@ NAN_METHOD(WinI2c::ReadPartial) {
       "(int length, Buffer buffer)"));
   }
 
-  Nan::HandleScope scope;
   uint32 length = info[0]->Uint32Value();
   v8::Local<v8::Object> bufferHandle = info[1].As<v8::Object>();
   int bytesRead = -1;
@@ -156,7 +154,7 @@ NAN_METHOD(WinI2c::ReadPartial) {
     }
   }
   catch (Exception^ e) {
-    Nan::ThrowError(Nan::ErrnoException(e->HResult, "WinI2c::ReadPartial", ""));
+    return Nan::ThrowError(Nan::ErrnoException(e->HResult, "WinI2c::ReadPartial", ""));
   }
 
   for (int i = 0; i < readBuf->Length; i++) {
@@ -176,7 +174,6 @@ NAN_METHOD(WinI2c::Write) {
       "incorrect arguments passed to WinI2c::Write"));
   }
 
-  Nan::HandleScope scope;
   std::vector<BYTE> bytes;
   v8::Handle<v8::Value> val;
   v8::Local<v8::Array> arr = Nan::New<v8::Array>();
@@ -192,7 +189,7 @@ NAN_METHOD(WinI2c::Write) {
   try {
     obj->_i2cDevice->Write(ArrayReference<BYTE>(bytes.data(), static_cast<unsigned int>(bytes.size())));
   } catch (Exception^ e) {
-    Nan::ThrowError(Nan::ErrnoException(e->HResult, "WinI2c::Write", ""));
+    return Nan::ThrowError(Nan::ErrnoException(e->HResult, "WinI2c::Write", ""));
   }
 }
 
@@ -204,8 +201,7 @@ NAN_METHOD(WinI2c::WritePartial) {
       "incorrect arguments passed to WinI2c::WritePartial"
       "(int length, Buffer buffer)"));
   }
-  
-  Nan::HandleScope scope;
+
   uint32 length = info[0]->Uint32Value();
   v8::Local<v8::Object> bufferHandle = info[1].As<v8::Object>();
   int bytesWritten = -1;
@@ -242,7 +238,7 @@ NAN_METHOD(WinI2c::WritePartial) {
     }
   }
   catch (Exception^ e) {
-    Nan::ThrowError(Nan::ErrnoException(e->HResult, "WinI2c::WritePartial", ""));
+    return Nan::ThrowError(Nan::ErrnoException(e->HResult, "WinI2c::WritePartial", ""));
   }
 
   if (bytesWritten == -1) {
@@ -253,7 +249,7 @@ NAN_METHOD(WinI2c::WritePartial) {
 }
 
 NAN_METHOD(WinI2c::WriteRead) {
-  Nan::ThrowError(Nan::ErrnoException(EPERM, "WinI2c::WriteRead", "Not Implemented"));
+  return Nan::ThrowError(Nan::ErrnoException(EPERM, "WinI2c::WriteRead", "Not Implemented"));
 }
 
 NAN_METHOD(WinI2c::WriteReadPartial) {
@@ -266,7 +262,6 @@ NAN_METHOD(WinI2c::WriteReadPartial) {
       "(int cmd, int length, Buffer buffer)"));
   }
 
-  Nan::HandleScope scope;
   uint32 length = info[1]->Uint32Value();
   v8::Local<v8::Object> bufferHandle = info[2].As<v8::Object>();
   int bytesRead = -1;
@@ -301,7 +296,7 @@ NAN_METHOD(WinI2c::WriteReadPartial) {
     }
   }
   catch (Exception^ e) {
-    Nan::ThrowError(Nan::ErrnoException(e->HResult, "WinI2c::WriteReadPartial", ""));
+    return Nan::ThrowError(Nan::ErrnoException(e->HResult, "WinI2c::WriteReadPartial", ""));
   }
 
   for (int i = 0; i < readBuf->Length; i++) {

--- a/src/win/i2c.cc
+++ b/src/win/i2c.cc
@@ -2,6 +2,7 @@
 #include <ppltasks.h>
 #include <vector>
 #include <iostream>
+#include "..\util.h"
 
 using v8::FunctionTemplate;
 using namespace concurrency;
@@ -15,15 +16,18 @@ NAN_MODULE_INIT(WinI2c::Init) {
   tpl->SetClassName(Nan::New("WinI2c").ToLocalChecked());
   tpl->InstanceTemplate()->SetInternalFieldCount(6);
 
-  Nan::SetPrototypeMethod(tpl, "openSync", OpenSync);
-  Nan::SetPrototypeMethod(tpl, "closeSync", CloseSync);
-  Nan::SetPrototypeMethod(tpl, "read", Read);
+  Nan::SetPrototypeMethod(tpl, "getController", GetController);
+  Nan::SetPrototypeMethod(tpl, "getControllerSync", GetControllerSync);
+  Nan::SetPrototypeMethod(tpl, "closeDevice", CloseDevice);
+  Nan::SetPrototypeMethod(tpl, "closeDeviceSync", CloseDeviceSync);
   Nan::SetPrototypeMethod(tpl, "readPartial", ReadPartial);
-  Nan::SetPrototypeMethod(tpl, "write", Write);
+  Nan::SetPrototypeMethod(tpl, "readPartialSync", ReadPartialSync);
   Nan::SetPrototypeMethod(tpl, "writePartial", WritePartial);
-  Nan::SetPrototypeMethod(tpl, "writeRead", WriteRead);
+  Nan::SetPrototypeMethod(tpl, "writePartialSync", WritePartialSync);
+  Nan::SetPrototypeMethod(tpl, "createDevice", CreateDevice);
+  Nan::SetPrototypeMethod(tpl, "createDeviceSync", CreateDeviceSync);
   Nan::SetPrototypeMethod(tpl, "writeReadPartial", WriteReadPartial);
-  Nan::SetPrototypeMethod(tpl, "setDevice", SetDevice);
+  Nan::SetPrototypeMethod(tpl, "writeReadPartialSync", WriteReadPartialSync);
 
   constructor.Reset(Nan::GetFunction(tpl).ToLocalChecked());
   Nan::Set(target, Nan::New("WinI2c").ToLocalChecked(), Nan::GetFunction(tpl).ToLocalChecked());
@@ -51,11 +55,63 @@ NAN_METHOD(WinI2c::New) {
   }
 }
 
-NAN_METHOD(WinI2c::OpenSync) {
+class GetControllerWorker : public I2cAsyncWorker {
+public:
+    GetControllerWorker(
+    Nan::Callback *callback,
+    WinI2c* obj,
+    std::wstring controllerName
+  ) : I2cAsyncWorker(callback), obj(obj), controllerName(controllerName) { }
+
+  ~GetControllerWorker() {}
+
+  void Execute() {   
+    String^ deviceSelector = I2cDevice::GetDeviceSelector(ref new Platform::String(controllerName.c_str()));
+    DeviceInformationCollection^ i2cDeviceControllers = create_task(DeviceInformation::FindAllAsync(deviceSelector)).get();
+    
+    if (nullptr == i2cDeviceControllers) {
+      return Nan::ThrowError(Nan::ErrnoException(EPERM, "getController", "DeviceInformation::FindAllAsync failed to return controller(s)"));
+    }
+
+    obj->SetControllerId(i2cDeviceControllers->GetAt(0)->Id);
+  }
+
+  void HandleOKCallback() {
+    Nan::HandleScope scope;
+    v8::Local<v8::Value> argv[] = { Nan::Null() };
+    callback->Call(1, argv);
+  }
+
+private:
+  WinI2c* obj;
+  std::wstring controllerName;
+};
+
+NAN_METHOD(WinI2c::GetController) {
+  if (info.Length() < 1 ||
+      !info[0]->IsString() ||
+      !info[1]->IsFunction()) {
+    return Nan::ThrowError(Nan::ErrnoException(EINVAL, "getController",
+      "incorrect arguments passed to getController"
+      "(string i2cControllerName, function cb)"));
+  }
+
+  v8::String::Utf8Value str(info[0]->ToString());
+  std::string stdStr = std::string(*str);
+  std::wstring controllerName;
+  controllerName.assign(stdStr.begin(), stdStr.end());
+
+  Nan::Callback *callback = new Nan::Callback(info[1].As<v8::Function>());
+  WinI2c* obj = Nan::ObjectWrap::Unwrap<WinI2c>(info.This());
+  
+  Nan::AsyncQueueWorker(new GetControllerWorker(callback, obj, controllerName));
+}
+
+NAN_METHOD(WinI2c::GetControllerSync) {
   if (info.Length() < 1 ||
       !info[0]->IsString()) {
-    return Nan::ThrowError(Nan::ErrnoException(EINVAL, "WinI2c::OpenSync",
-      "incorrect arguments passed to WinI2c::OpenSync"
+    return Nan::ThrowError(Nan::ErrnoException(EINVAL, "getControllerSync",
+      "incorrect arguments passed to getControllerSync"
       "(string i2cControllerName)"));
   }
 
@@ -68,19 +124,53 @@ NAN_METHOD(WinI2c::OpenSync) {
   DeviceInformationCollection^ i2cDeviceControllers = create_task(DeviceInformation::FindAllAsync(deviceSelector)).get();
 
   if (nullptr == i2cDeviceControllers) {
-    return Nan::ThrowError(Nan::ErrnoException(EPERM, "WinI2c::OpenSync", "DeviceInformation::FindAllAsync failed to return controller(s)"));
+    return Nan::ThrowError(Nan::ErrnoException(EPERM, "getControllerSync", "DeviceInformation::FindAllAsync failed to return controller(s)"));
   }
 
   WinI2c* obj = Nan::ObjectWrap::Unwrap<WinI2c>(info.This());
-  obj->_i2cDeviceId = i2cDeviceControllers->GetAt(0)->Id;
+  obj->_i2cControllerId = i2cDeviceControllers->GetAt(0)->Id;
 }
 
-NAN_METHOD(WinI2c::SetDevice) {
-  if (info.Length() < 1 ||
-      !info[0]->IsInt32()) {
-    return Nan::ThrowError(Nan::ErrnoException(EINVAL, "WinI2c::SetDevice",
-      "incorrect arguments passed to WinI2c::SetDevice"
-      "(int deviceAddress)"));
+class CreateDeviceWorker : public I2cAsyncWorker {
+public:
+    CreateDeviceWorker(
+        Nan::Callback *callback,
+        WinI2c* obj,
+        I2cConnectionSettings^ settings
+        ) : I2cAsyncWorker(callback), obj(obj), settings(settings) { }
+
+    ~CreateDeviceWorker() {}
+
+    void Execute() {
+      I2cDevice^ device = create_task(I2cDevice::FromIdAsync(obj->GetControllerId(), settings)).get();
+      if (nullptr == device) {
+        return Nan::ThrowError(Nan::ErrnoException(EPERM, "createDevice",
+          "I2cDevice::FromIdAsync failed to return an i2c device"));
+      } else {
+          obj->SetDevice(device);
+      }
+    }
+
+    void HandleOKCallback() {
+        Nan::HandleScope scope;
+        v8::Local<v8::Value> argv[] = { Nan::Null() };
+        callback->Call(1, argv);
+    }
+
+private:
+    WinI2c* obj;
+    I2cConnectionSettings^ settings;
+};
+
+NAN_METHOD(WinI2c::CreateDevice) {
+  if (info.Length() < 3 ||
+      !info[0]->IsInt32() ||
+      !info[1]->IsInt32() ||
+      !info[2]->IsInt32() ||
+      !info[3]->IsFunction()) {
+    return Nan::ThrowError(Nan::ErrnoException(EINVAL, "createDevice",
+      "incorrect arguments passed to createDevice"
+      "(int deviceAddress, int I2cBusSpeed enum value, int I2cSharingMode enum value, function cb)"));
   }
 
   WinI2c* obj = Nan::ObjectWrap::Unwrap<WinI2c>(info.This());
@@ -88,18 +178,72 @@ NAN_METHOD(WinI2c::SetDevice) {
   if(nullptr == obj->_i2cDevice) {
     I2cConnectionSettings^ settings = ref new I2cConnectionSettings(info[0]->Int32Value());
     
-    //TODO: Expose as properties for the user to change
-    settings->BusSpeed = I2cBusSpeed::FastMode;
-    settings->SharingMode = I2cSharingMode::Exclusive;
+    int busSpeed = info[1]->Uint32Value();
+    if (busSpeed < 0 || busSpeed > 1) {
+      return Nan::ThrowError(Nan::ErrnoException(EPERM, "createDevice",
+        "Bus speed out of range. 0=StandardMode, 1=FastMode"));
+    }
+    int sharingMode = info[2]->Uint32Value();
+    if (sharingMode < 0 || sharingMode > 1) {
+      return Nan::ThrowError(Nan::ErrnoException(EPERM, "createDevice",
+        "Sharing mode out of range. 0=Exclusive, 1=Shared "));
+    }
+    settings->BusSpeed = static_cast<I2cBusSpeed>(busSpeed);
+    settings->SharingMode = static_cast<I2cSharingMode>(sharingMode);
+
+    Nan::Callback *callback = new Nan::Callback(info[3].As<v8::Function>());
+
+    Nan::AsyncQueueWorker(new CreateDeviceWorker(callback, obj, settings));
+  }
+}
+
+NAN_METHOD(WinI2c::CreateDeviceSync) {
+  if (info.Length() < 3 ||
+      !info[0]->IsInt32() ||
+      !info[1]->IsInt32() ||
+      !info[2]->IsInt32()) {
+    return Nan::ThrowError(Nan::ErrnoException(EINVAL, "createDeviceSync",
+      "incorrect arguments passed to createDeviceSync"
+      "(int deviceAddress, int I2cBusSpeed enum value, int I2cSharingMode enum value)"));
+  }
+
+  WinI2c* obj = Nan::ObjectWrap::Unwrap<WinI2c>(info.This());
+
+  if(nullptr == obj->_i2cDevice) {
+    I2cConnectionSettings^ settings = ref new I2cConnectionSettings(info[0]->Int32Value());
     
-    obj->_i2cDevice = create_task(I2cDevice::FromIdAsync(obj->_i2cDeviceId, settings)).get();
+    int busSpeed = info[1]->Uint32Value();
+    if (busSpeed < 0 || busSpeed > 1) {
+      return Nan::ThrowError(Nan::ErrnoException(EPERM, "createDeviceSync",
+        "Bus speed out of range. 0=StandardMode, 1=FastMode"));
+    }
+    int sharingMode = info[2]->Uint32Value();
+    if (sharingMode < 0 || sharingMode > 1) {
+      return Nan::ThrowError(Nan::ErrnoException(EPERM, "createDeviceSync",
+        "Sharing mode out of range. 0=Exclusive, 1=Shared "));
+    }
+    settings->BusSpeed = static_cast<I2cBusSpeed>(busSpeed);
+    settings->SharingMode = static_cast<I2cSharingMode>(sharingMode);
+    
+    obj->_i2cDevice = create_task(I2cDevice::FromIdAsync(obj->_i2cControllerId, settings)).get();
     if (nullptr == obj->_i2cDevice) {
-      return Nan::ThrowError(Nan::ErrnoException(EPERM, "WinI2c::SetDevice", "I2cDevice::FromIdAsync failed to return an i2c device"));
+      return Nan::ThrowError(Nan::ErrnoException(EPERM, "createDeviceSync",
+        "I2cDevice::FromIdAsync failed to return an i2c device"));
     }
   }
 }
 
-NAN_METHOD(WinI2c::CloseSync) {
+NAN_METHOD(WinI2c::CloseDevice) {
+    WinI2c* obj = Nan::ObjectWrap::Unwrap<WinI2c>(info.This());
+
+    //From https://msdn.microsoft.com/en-us/library/windows.devices.i2c.i2cdevice.close.aspx
+    // You cannot call Close methods through Visual C++ component extensions(C++ / CX) on 
+    // Windows Runtime class instances where the class implemented IClosable.Instead, C++ / CX code 
+    // for runtime classes should call the destructor or set the last reference to null.
+    obj->_i2cDevice = nullptr;
+}
+
+NAN_METHOD(WinI2c::CloseDeviceSync) {
   WinI2c* obj = Nan::ObjectWrap::Unwrap<WinI2c>(info.This());
 
   //From https://msdn.microsoft.com/en-us/library/windows.devices.i2c.i2cdevice.close.aspx
@@ -109,205 +253,16 @@ NAN_METHOD(WinI2c::CloseSync) {
   obj->_i2cDevice = nullptr;
 }
 
-NAN_METHOD(WinI2c::Read) {
-  return Nan::ThrowError(Nan::ErrnoException(EPERM, "WinI2c::Read", "Not Implemented"));
+void WinI2c::SetControllerId(String^ controllerId) {
+  _i2cControllerId = controllerId;
 }
 
-NAN_METHOD(WinI2c::ReadPartial) {
-  if (info.Length() < 2 ||
-      !info[0]->IsInt32() ||
-      !info[1]->IsObject()) {
-    return Nan::ThrowError(Nan::ErrnoException(EINVAL, "WinI2c::ReadPartial",
-      "incorrect arguments passed to WinI2c::ReadPartial"
-      "(int length, Buffer buffer)"));
-  }
-
-  uint32 length = info[0]->Uint32Value();
-  v8::Local<v8::Object> bufferHandle = info[1].As<v8::Object>();
-  int bytesRead = -1;
-  byte* bufferData = (byte*)node::Buffer::Data(bufferHandle);
-  size_t bufferLength = node::Buffer::Length(bufferHandle);
-
-  if (length > bufferLength) {
-    return Nan::ThrowError(Nan::ErrnoException(EINVAL, "WinI2c::ReadPartial",
-      "buffer passed to WinI2c::Read contains less than 'length' bytes"));
-  }
-
-  auto readBuf = ref new Platform::Array<BYTE>(length);
-  WinI2c* obj = Nan::ObjectWrap::Unwrap<WinI2c>(info.This());
-  try {
-    I2cTransferResult result = obj->_i2cDevice->ReadPartial(readBuf);
-
-    switch (result.Status) {
-      case I2cTransferStatus::FullTransfer:
-        bytesRead = result.BytesTransferred;
-        break;
-      case I2cTransferStatus::PartialTransfer:
-        bytesRead = result.BytesTransferred;
-        wprintf(L"%d bytes partially transferred\n", bytesRead);
-        break;
-      case I2cTransferStatus::SlaveAddressNotAcknowledged:
-        wprintf(L"Slave address was not acknowledged\n");
-        break;
-      default:
-        wprintf(L"Invalid transfer status value\n");
-    }
-  }
-  catch (Exception^ e) {
-    return Nan::ThrowError(Nan::ErrnoException(e->HResult, "WinI2c::ReadPartial", ""));
-  }
-
-  for (int i = 0; i < readBuf->Length; i++) {
-    bufferData[i] = readBuf[i];
-  }
-
-  if (bytesRead == -1) {
-    return Nan::ThrowError(Nan::ErrnoException(errno, "WinI2c::ReadPartial", ""));
-  }
-
-  info.GetReturnValue().Set(Nan::New<v8::Integer>(bytesRead));
+String^ WinI2c::GetControllerId() {
+  return _i2cControllerId;
 }
 
-NAN_METHOD(WinI2c::Write) {
-  if (info.Length() < 1 || !info[0]->IsArray()) {
-    return Nan::ThrowError(Nan::ErrnoException(EINVAL, "WinI2c::Write",
-      "incorrect arguments passed to WinI2c::Write"));
-  }
-
-  std::vector<BYTE> bytes;
-  v8::Handle<v8::Value> val;
-  v8::Local<v8::Array> arr = Nan::New<v8::Array>();
-
-  v8::Handle<v8::Array> jsArray = v8::Handle<v8::Array>::Cast(info[0]);
-  for (unsigned int i = 0; i < jsArray->Length(); i++) {
-    val = jsArray->Get(i);
-    bytes.push_back(static_cast<BYTE>(val->Uint32Value()));
-    Nan::Set(arr, i, val);
-  }
-
-  WinI2c* obj = Nan::ObjectWrap::Unwrap<WinI2c>(info.This());
-  try {
-    obj->_i2cDevice->Write(ArrayReference<BYTE>(bytes.data(), static_cast<unsigned int>(bytes.size())));
-  } catch (Exception^ e) {
-    return Nan::ThrowError(Nan::ErrnoException(e->HResult, "WinI2c::Write", ""));
-  }
-}
-
-NAN_METHOD(WinI2c::WritePartial) {
-  if (info.Length() < 2 ||
-      !info[0]->IsInt32() ||
-      !info[1]->IsObject()) {
-    return Nan::ThrowError(Nan::ErrnoException(EINVAL, "WinI2c::WritePartial",
-      "incorrect arguments passed to WinI2c::WritePartial"
-      "(int length, Buffer buffer)"));
-  }
-
-  uint32 length = info[0]->Uint32Value();
-  v8::Local<v8::Object> bufferHandle = info[1].As<v8::Object>();
-  int bytesWritten = -1;
-  byte* bufferData = (byte*)node::Buffer::Data(bufferHandle);
-  size_t bufferLength = node::Buffer::Length(bufferHandle);
-
-  if (length > bufferLength) {
-    return Nan::ThrowError(Nan::ErrnoException(EINVAL, "WinI2c::WritePartial",
-      "buffer passed to WinI2c::WritePartial contains less than 'length' bytes"));
-  }
-
-  auto writeBuf = ref new Platform::Array<BYTE>(length);
-
-  for (int i = 0; i < writeBuf->Length; i++) {
-    writeBuf->set(i, bufferData[i]);
-  }
-
-  WinI2c* obj = Nan::ObjectWrap::Unwrap<WinI2c>(info.This());
-  try {
-    I2cTransferResult result = obj->_i2cDevice->WritePartial(writeBuf);
-    switch (result.Status) {
-      case I2cTransferStatus::FullTransfer:
-        bytesWritten = result.BytesTransferred;
-        break;
-      case I2cTransferStatus::PartialTransfer:
-        bytesWritten = result.BytesTransferred;
-        wprintf(L"%d bytes partially transferred\n", bytesWritten);
-        break;
-      case I2cTransferStatus::SlaveAddressNotAcknowledged:
-        wprintf(L"Slave address was not acknowledged\n");
-        break;
-      default:
-        wprintf(L"Invalid transfer status value\n");
-    }
-  }
-  catch (Exception^ e) {
-    return Nan::ThrowError(Nan::ErrnoException(e->HResult, "WinI2c::WritePartial", ""));
-  }
-
-  if (bytesWritten == -1) {
-    return Nan::ThrowError(Nan::ErrnoException(errno, "WinI2c::WritePartial", ""));
-  }
-
-  info.GetReturnValue().Set(Nan::New<v8::Integer>(bytesWritten));
-}
-
-NAN_METHOD(WinI2c::WriteRead) {
-  return Nan::ThrowError(Nan::ErrnoException(EPERM, "WinI2c::WriteRead", "Not Implemented"));
-}
-
-NAN_METHOD(WinI2c::WriteReadPartial) {
-  if (info.Length() < 3 ||
-      !info[0]->IsInt32() ||
-      !info[1]->IsInt32() ||
-      !info[2]->IsObject()) {
-    return Nan::ThrowError(Nan::ErrnoException(EINVAL, "WinI2c::WriteReadPartial",
-      "incorrect arguments passed to WinI2c::WriteReadPartial"
-      "(int cmd, int length, Buffer buffer)"));
-  }
-
-  uint32 length = info[1]->Uint32Value();
-  v8::Local<v8::Object> bufferHandle = info[2].As<v8::Object>();
-  int bytesRead = -1;
-  byte* bufferData = (byte*)node::Buffer::Data(bufferHandle);
-  size_t bufferLength = node::Buffer::Length(bufferHandle);
-
-  if (length > bufferLength) {
-    return Nan::ThrowError(Nan::ErrnoException(EINVAL, "WinI2c::WriteReadPartial",
-      "buffer passed to WinI2c::WriteReadPartial contains less than 'length' bytes"));
-  }
-  
-  auto readBuf = ref new Platform::Array<BYTE>(length);
-  auto writeBuf = ref new Platform::Array<BYTE>(1);
-  writeBuf->set(0, info[0]->Int32Value());
-
-  WinI2c* obj = Nan::ObjectWrap::Unwrap<WinI2c>(info.This());
-  try {
-    I2cTransferResult result = obj->_i2cDevice->WriteReadPartial(writeBuf, readBuf);
-    switch (result.Status) {
-      case I2cTransferStatus::FullTransfer:
-        bytesRead = result.BytesTransferred;
-        break;
-      case I2cTransferStatus::PartialTransfer:
-        bytesRead = result.BytesTransferred;
-        wprintf(L"%d bytes partially transferred\n", bytesRead);
-        break;
-      case I2cTransferStatus::SlaveAddressNotAcknowledged:
-        wprintf(L"Slave address was not acknowledged\n");
-        break;
-      default:
-        wprintf(L"Invalid transfer status value\n");
-    }
-  }
-  catch (Exception^ e) {
-    return Nan::ThrowError(Nan::ErrnoException(e->HResult, "WinI2c::WriteReadPartial", ""));
-  }
-
-  for (int i = 0; i < readBuf->Length; i++) {
-    bufferData[i] = readBuf[i];
-  }
-
-  if (bytesRead == -1) {
-    return Nan::ThrowError(Nan::ErrnoException(errno, "WinI2c::WriteReadPartial", ""));
-  }
-
-  info.GetReturnValue().Set(Nan::New<v8::Integer>(bytesRead));
+void WinI2c::SetDevice(I2cDevice^ device) {
+  _i2cDevice = device;
 }
 
 NODE_MODULE(i2c, WinI2c::Init)

--- a/src/win/i2c.h
+++ b/src/win/i2c.h
@@ -1,0 +1,29 @@
+#include <nan.h>
+
+using namespace Platform;
+using namespace Windows::Devices::Enumeration;
+using namespace Windows::Devices::SerialCommunication;
+using namespace Windows::Foundation;
+using namespace Windows::Devices::I2c;
+
+class WinI2c : public Nan::ObjectWrap {
+public:
+  static NAN_MODULE_INIT(Init);
+  static NAN_METHOD(OpenSync);
+  static NAN_METHOD(CloseSync);
+  static NAN_METHOD(Read);
+  static NAN_METHOD(ReadPartial);
+  static NAN_METHOD(Write);
+  static NAN_METHOD(WritePartial);
+  static NAN_METHOD(WriteRead);
+  static NAN_METHOD(WriteReadPartial);
+  static NAN_METHOD(New);
+  static NAN_METHOD(SetDevice);
+
+private:
+  explicit WinI2c();
+  ~WinI2c();
+  static Nan::Persistent<v8::Function> constructor;
+  I2cDevice^ _i2cDevice;
+  String^ _i2cDeviceId;
+};

--- a/src/win/i2c.h
+++ b/src/win/i2c.h
@@ -6,24 +6,32 @@ using namespace Windows::Devices::SerialCommunication;
 using namespace Windows::Foundation;
 using namespace Windows::Devices::I2c;
 
+#define I2C_SMBUS_I2C_BLOCK_MAX	32
+
 class WinI2c : public Nan::ObjectWrap {
 public:
   static NAN_MODULE_INIT(Init);
-  static NAN_METHOD(OpenSync);
-  static NAN_METHOD(CloseSync);
-  static NAN_METHOD(Read);
-  static NAN_METHOD(ReadPartial);
-  static NAN_METHOD(Write);
-  static NAN_METHOD(WritePartial);
-  static NAN_METHOD(WriteRead);
-  static NAN_METHOD(WriteReadPartial);
   static NAN_METHOD(New);
-  static NAN_METHOD(SetDevice);
+  static NAN_METHOD(GetController);
+  static NAN_METHOD(GetControllerSync);
+  static NAN_METHOD(CloseDevice);
+  static NAN_METHOD(CloseDeviceSync);
+  static NAN_METHOD(ReadPartial);
+  static NAN_METHOD(ReadPartialSync);
+  static NAN_METHOD(WritePartial);
+  static NAN_METHOD(WritePartialSync);
+  static NAN_METHOD(CreateDevice);
+  static NAN_METHOD(CreateDeviceSync);
+  static NAN_METHOD(WriteReadPartial);
+  static NAN_METHOD(WriteReadPartialSync);
+  String^ GetControllerId();
+  void SetControllerId(String^ controllerId);
+  void SetDevice(I2cDevice^ device);
 
 private:
   explicit WinI2c();
   ~WinI2c();
   static Nan::Persistent<v8::Function> constructor;
   I2cDevice^ _i2cDevice;
-  String^ _i2cDeviceId;
+  String^ _i2cControllerId;
 };

--- a/src/win/readPartial.cc
+++ b/src/win/readPartial.cc
@@ -1,0 +1,145 @@
+#include "i2c.h"
+#include "..\util.h"
+
+static bool DoReadPartial(I2cDevice^ device, Array<BYTE>^ readBuf, int* bytesRead) {
+  I2cTransferResult result = device->ReadPartial(readBuf);
+
+  switch (result.Status) {
+    case I2cTransferStatus::FullTransfer:
+      *bytesRead = result.BytesTransferred;
+      break;
+    case I2cTransferStatus::PartialTransfer:
+      *bytesRead = result.BytesTransferred;
+      break;
+    case I2cTransferStatus::SlaveAddressNotAcknowledged:
+      wprintf(L"Slave address was not acknowledged\n");
+      return false;
+    default:
+      wprintf(L"Invalid transfer status value\n");
+      return false;
+  }
+
+  return true;
+}
+
+class ReadPartialWorker : public I2cAsyncWorker {
+public:
+    ReadPartialWorker(
+    Nan::Callback *callback,
+    I2cDevice^ device,
+    uint32 length,
+    byte* block,
+    v8::Local<v8::Object> &bufferHandle
+  ) : I2cAsyncWorker(callback), device(device), length(length), block(block), bytesRead(-1) {
+    SaveToPersistent("buffer", bufferHandle);
+  }
+
+  ~ReadPartialWorker() {}
+
+  void Execute() {
+    auto readBuf = ref new Platform::Array<BYTE>(length);
+
+    if (!DoReadPartial(device, readBuf, &bytesRead) || bytesRead == -1) {
+      SetErrorNo(EIO);
+      SetErrorSyscall("readPartial");
+    }
+
+    for (int i = 0; i < readBuf->Length; i++) {
+      block[i] = readBuf[i];
+    }
+  }
+
+  void HandleOKCallback() {
+    Nan::HandleScope scope;
+
+    v8::Local<v8::Value> bufferHandle = GetFromPersistent("buffer");
+
+    v8::Local<v8::Value> argv[] = {
+      Nan::Null(),
+      Nan::New<v8::Integer>(bytesRead),
+      bufferHandle
+    };
+
+    callback->Call(3, argv);
+  }
+
+private:
+  I2cDevice^ device;
+  uint32 length;
+  byte* block;
+  int bytesRead;
+};
+
+NAN_METHOD(WinI2c::ReadPartial) {
+  if (info.Length() < 3 ||
+      !info[0]->IsUint32() ||
+      !info[1]->IsObject() ||
+      !info[2]->IsFunction()) {
+    return Nan::ThrowError(Nan::ErrnoException(EINVAL, "readPartial",
+      "incorrect arguments passed to readPartial"
+      "(int length, Buffer buffer, function cb)"));
+  }
+   
+  uint32 length = info[0]->Uint32Value();
+  v8::Local<v8::Object> bufferHandle = info[1].As<v8::Object>();
+  Nan::Callback *callback = new Nan::Callback(info[2].As<v8::Function>());
+
+  byte* bufferData = (byte*)node::Buffer::Data(bufferHandle);
+  size_t bufferLength = node::Buffer::Length(bufferHandle);
+
+  if (length > I2C_SMBUS_I2C_BLOCK_MAX) {
+    return Nan::ThrowError(Nan::ErrnoException(EINVAL, "readPartial",
+      "readPartial can't read blocks with more than 32 bytes"));
+  }
+
+  if (length > bufferLength) {
+    return Nan::ThrowError(Nan::ErrnoException(EINVAL, "readPartial",
+      "buffer passed to readPartial contains less than 'length' bytes"));
+  }
+
+  WinI2c* obj = Nan::ObjectWrap::Unwrap<WinI2c>(info.This());
+
+  Nan::AsyncQueueWorker(new ReadPartialWorker(
+    callback,
+    obj->_i2cDevice,
+    length,
+    bufferData,
+    bufferHandle
+  ));
+}
+
+NAN_METHOD(WinI2c::ReadPartialSync) {
+  if (info.Length() < 2 ||
+      !info[0]->IsInt32() ||
+      !info[1]->IsObject()) {
+    return Nan::ThrowError(Nan::ErrnoException(EINVAL, "readPartialSync",
+      "incorrect arguments passed to readPartialSync"
+      "(int length, Buffer buffer)"));
+  }
+
+  uint32 length = info[0]->Uint32Value();
+  v8::Local<v8::Object> bufferHandle = info[1].As<v8::Object>();
+  int bytesRead = -1;
+  byte* bufferData = (byte*)node::Buffer::Data(bufferHandle);
+  size_t bufferLength = node::Buffer::Length(bufferHandle);
+
+  if (length > bufferLength) {
+    return Nan::ThrowError(Nan::ErrnoException(EINVAL, "readPartialSync",
+      "buffer passed to readPartialSync contains less than 'length' bytes"));
+  }
+
+  auto readBuf = ref new Platform::Array<BYTE>(length);
+
+  WinI2c* obj = Nan::ObjectWrap::Unwrap<WinI2c>(info.This());
+  DoReadPartial(obj->_i2cDevice, readBuf, &bytesRead);
+
+  if (bytesRead == -1) {
+    return Nan::ThrowError(Nan::ErrnoException(errno, "readPartialSync", ""));
+  }
+
+  for (uint32 i = 0; i < readBuf->Length; i++) {
+      bufferData[i] = readBuf[i];
+  }
+
+  info.GetReturnValue().Set(Nan::New<v8::Integer>(bytesRead));
+}

--- a/src/win/writePartial.cc
+++ b/src/win/writePartial.cc
@@ -1,0 +1,143 @@
+#include "i2c.h"
+#include "..\util.h"
+
+static bool DoWritePartial(I2cDevice^ device, Array<BYTE>^ writeBuf, int* bytesWritten) {
+  I2cTransferResult result = device->WritePartial(writeBuf);
+
+  switch (result.Status) {
+    case I2cTransferStatus::FullTransfer:
+      *bytesWritten = result.BytesTransferred;
+      break;
+    case I2cTransferStatus::PartialTransfer:
+      *bytesWritten = result.BytesTransferred;
+      break;
+    case I2cTransferStatus::SlaveAddressNotAcknowledged:
+      wprintf(L"Slave address was not acknowledged\n");
+      return false;
+    default:
+      wprintf(L"Invalid transfer status value\n");
+      return false;
+  }
+
+  return true;
+}
+
+class WritePartialWorker : public I2cAsyncWorker {
+public:
+    WritePartialWorker(
+    Nan::Callback *callback,
+    I2cDevice^ device,
+    uint32 length,
+    byte* block,
+    v8::Local<v8::Object> &bufferHandle
+  ) : I2cAsyncWorker(callback), device(device), length(length), block(block), bytesWritten(-1) {
+    SaveToPersistent("buffer", bufferHandle);
+  }
+
+  ~WritePartialWorker() {}
+
+  void Execute() {
+    auto writeBuf = ref new Platform::Array<BYTE>(length);
+    for (int i = 0; i < writeBuf->Length; i++) {
+      writeBuf->set(i, block[i]);
+    }
+
+    if (!DoWritePartial(device, writeBuf, &bytesWritten) || bytesWritten == -1) {
+      SetErrorNo(EIO);
+      SetErrorSyscall("writePartial");
+    }
+  }
+
+  void HandleOKCallback() {
+    Nan::HandleScope scope;
+
+    v8::Local<v8::Value> bufferHandle = GetFromPersistent("buffer");
+
+    v8::Local<v8::Value> argv[] = {
+      Nan::Null(),
+      Nan::New<v8::Integer>(bytesWritten),
+      bufferHandle
+    };
+
+    callback->Call(3, argv);
+  }
+
+private:
+  I2cDevice^ device;
+  uint32 length;
+  byte* block;
+  int bytesWritten;
+};
+
+NAN_METHOD(WinI2c::WritePartial) {
+  if (info.Length() < 3 ||
+      !info[0]->IsUint32() ||
+      !info[1]->IsObject() ||
+      !info[2]->IsFunction()) {
+    return Nan::ThrowError(Nan::ErrnoException(EINVAL, "writePartial",
+      "incorrect arguments passed to writePartial"
+      "(int length, Buffer buffer, function cb)"));
+  }
+   
+  uint32 length = info[0]->Uint32Value();
+  v8::Local<v8::Object> bufferHandle = info[1].As<v8::Object>();
+  Nan::Callback *callback = new Nan::Callback(info[2].As<v8::Function>());
+
+  byte* bufferData = (byte*)node::Buffer::Data(bufferHandle);
+  size_t bufferLength = node::Buffer::Length(bufferHandle);
+
+  if (length > I2C_SMBUS_I2C_BLOCK_MAX) {
+    return Nan::ThrowError(Nan::ErrnoException(EINVAL, "writePartial",
+      "writePartial can't write blocks with more than 32 bytes"));
+  }
+
+  if (length > bufferLength) {
+    return Nan::ThrowError(Nan::ErrnoException(EINVAL, "writePartial",
+      "buffer passed to readPartial contains less than 'length' bytes"));
+  }
+
+  WinI2c* obj = Nan::ObjectWrap::Unwrap<WinI2c>(info.This());
+
+  Nan::AsyncQueueWorker(new WritePartialWorker(
+    callback,
+    obj->_i2cDevice,
+    length,
+    bufferData,
+    bufferHandle
+  ));
+}
+
+NAN_METHOD(WinI2c::WritePartialSync) {
+  if (info.Length() < 2 ||
+      !info[0]->IsInt32() ||
+      !info[1]->IsObject()) {
+    return Nan::ThrowError(Nan::ErrnoException(EINVAL, "writePartialSync",
+      "incorrect arguments passed to writePartialSync"
+      "(int length, Buffer buffer)"));
+  }
+
+  uint32 length = info[0]->Uint32Value();
+  v8::Local<v8::Object> bufferHandle = info[1].As<v8::Object>();
+  int bytesWritten = -1;
+  byte* bufferData = (byte*)node::Buffer::Data(bufferHandle);
+  size_t bufferLength = node::Buffer::Length(bufferHandle);
+
+  if (length > bufferLength) {
+    return Nan::ThrowError(Nan::ErrnoException(EINVAL, "writePartialSync",
+      "buffer passed to writePartialSync contains less than 'length' bytes"));
+  }
+
+  auto writeBuf = ref new Platform::Array<BYTE>(length);
+  for (int i = 0; i < writeBuf->Length; i++) {
+    writeBuf->set(i, bufferData[i]);
+  }
+
+  WinI2c* obj = Nan::ObjectWrap::Unwrap<WinI2c>(info.This());
+  DoWritePartial(obj->_i2cDevice, writeBuf, &bytesWritten);
+
+  if (bytesWritten == -1) {
+    return Nan::ThrowError(Nan::ErrnoException(errno, "writePartialSync", ""));
+  }
+
+  info.GetReturnValue().Set(Nan::New<v8::Integer>(bytesWritten));
+}

--- a/src/win/writeReadPartial.cc
+++ b/src/win/writeReadPartial.cc
@@ -1,0 +1,161 @@
+#include "i2c.h"
+#include "..\util.h"
+
+static bool DoWriteReadPartial(I2cDevice^ device, Array<BYTE>^ writeBuf, Array<BYTE>^ readBuf, int* bytesRead) {
+  I2cTransferResult result = device->WriteReadPartial(writeBuf, readBuf);
+
+  switch (result.Status) {
+    case I2cTransferStatus::FullTransfer:
+      *bytesRead = result.BytesTransferred;
+      break;
+    case I2cTransferStatus::PartialTransfer:
+      *bytesRead = result.BytesTransferred;
+      break;
+    case I2cTransferStatus::SlaveAddressNotAcknowledged:
+      wprintf(L"Slave address was not acknowledged\n");
+      return false;
+    default:
+      wprintf(L"Invalid transfer status value\n");
+      return false;
+  }
+
+  return true;
+}
+
+class WriteReadPartialWorker : public I2cAsyncWorker {
+public:
+    WriteReadPartialWorker(
+    Nan::Callback *callback,
+    I2cDevice^ device,
+    byte cmd,
+    uint32 length,
+    byte* block,
+    v8::Local<v8::Object> &bufferHandle
+  ) : I2cAsyncWorker(callback), device(device), cmd(cmd), length(length), block(block), bytesRead(-1) {
+    SaveToPersistent("buffer", bufferHandle);
+  }
+
+  ~WriteReadPartialWorker() {}
+
+  void Execute() {
+    auto readBuf = ref new Platform::Array<BYTE>(length);
+    auto writeBuf = ref new Platform::Array<BYTE>(1);
+    writeBuf->set(0, cmd);
+
+    if (!DoWriteReadPartial(device, writeBuf, readBuf, &bytesRead) || bytesRead == -1) {
+	  SetErrorNo(EIO);
+      SetErrorSyscall("writeReadPartial");
+    }
+
+    for (int i = 0; i < readBuf->Length; i++) {
+      block[i] = readBuf[i];
+    }
+  }
+
+  void HandleOKCallback() {
+    Nan::HandleScope scope;
+
+    v8::Local<v8::Value> bufferHandle = GetFromPersistent("buffer");
+
+    v8::Local<v8::Value> argv[] = {
+      Nan::Null(),
+      Nan::New<v8::Integer>(bytesRead),
+      bufferHandle
+    };
+
+    callback->Call(3, argv);
+  }
+
+private:
+  I2cDevice^ device;
+  byte cmd;
+  uint32 length;
+  byte* block;
+  int bytesRead;
+};
+
+NAN_METHOD(WinI2c::WriteReadPartial) {
+  if (info.Length() < 4 ||
+      !info[0]->IsInt32() ||
+      !info[1]->IsUint32() ||
+      !info[2]->IsObject() ||
+      !info[3]->IsFunction()) {
+    return Nan::ThrowError(Nan::ErrnoException(EINVAL, "writeReadPartial",
+      "incorrect arguments passed to writeReadPartial"
+      "(int cmd, int length, Buffer buffer, function cb)"));
+  }
+
+  byte cmd = info[0]->Int32Value();
+  uint32 length = info[1]->Uint32Value();
+  v8::Local<v8::Object> bufferHandle = info[2].As<v8::Object>();
+  Nan::Callback *callback = new Nan::Callback(info[3].As<v8::Function>());
+
+  byte* bufferData = (byte*)node::Buffer::Data(bufferHandle);
+  size_t bufferLength = node::Buffer::Length(bufferHandle);
+
+  if (length > I2C_SMBUS_I2C_BLOCK_MAX) {
+    return Nan::ThrowError(Nan::ErrnoException(EINVAL, "writeReadPartial",
+      "writeReadPartial can't read blocks with more than 32 bytes"));
+  }
+
+  if (length > bufferLength) {
+    return Nan::ThrowError(Nan::ErrnoException(EINVAL, "writeReadPartial",
+      "buffer passed to writeReadPartial contains less than 'length' bytes"));
+  }
+
+  WinI2c* obj = Nan::ObjectWrap::Unwrap<WinI2c>(info.This());
+
+  Nan::AsyncQueueWorker(new WriteReadPartialWorker(
+    callback,
+    obj->_i2cDevice,
+    cmd,
+    length,
+    bufferData,
+    bufferHandle
+  ));
+}
+
+NAN_METHOD(WinI2c::WriteReadPartialSync) {
+  if (info.Length() < 3 ||
+      !info[0]->IsInt32() ||
+      !info[1]->IsInt32() ||
+      !info[2]->IsObject()) {
+    return Nan::ThrowError(Nan::ErrnoException(EINVAL, "writeReadPartialSync",
+      "incorrect arguments passed to writeReadPartialSync"
+      "(int cmd, int length, Buffer buffer)"));
+  }
+
+  byte cmd = info[0]->Int32Value();
+  uint32 length = info[1]->Uint32Value();
+  v8::Local<v8::Object> bufferHandle = info[2].As<v8::Object>();
+  int bytesRead = -1;
+  byte* bufferData = (byte*)node::Buffer::Data(bufferHandle);
+  size_t bufferLength = node::Buffer::Length(bufferHandle);
+
+  if (length > I2C_SMBUS_I2C_BLOCK_MAX) {
+    return Nan::ThrowError(Nan::ErrnoException(EINVAL, "writeReadPartialSync",
+      "writeReadPartialSync can't read blocks with more than 32 bytes"));
+  }
+
+  if (length > bufferLength) {
+    return Nan::ThrowError(Nan::ErrnoException(EINVAL, "writeReadPartialSync",
+      "buffer passed to writeReadPartialSync contains less than 'length' bytes"));
+  }
+ 
+  auto readBuf = ref new Platform::Array<BYTE>(length);
+  auto writeBuf = ref new Platform::Array<BYTE>(1);
+  writeBuf->set(0, cmd);
+
+  WinI2c* obj = Nan::ObjectWrap::Unwrap<WinI2c>(info.This());
+  DoWriteReadPartial(obj->_i2cDevice, writeBuf, readBuf, &bytesRead);
+
+  if (bytesRead == -1) {
+    return Nan::ThrowError(Nan::ErrnoException(errno, "writeReadPartialSync", ""));
+  }
+
+  for (int i = 0; i < readBuf->Length; i++) {
+      bufferData[i] = readBuf[i];
+  }
+
+  info.GetReturnValue().Set(Nan::New<v8::Integer>(bytesRead));
+}

--- a/win-i2c-bus.js
+++ b/win-i2c-bus.js
@@ -1,0 +1,161 @@
+'use strict';
+
+var i2c = require('bindings')('i2c.node');
+
+// In this context:
+// Bus = i2c controller object (https://msdn.microsoft.com/en-us/library/windows.devices.i2c.i2ccontroller.aspx)
+// busNumber = name of i2c controller
+function Bus(busNumber) {
+  if (!(this instanceof Bus)) {
+    return new Bus(busNumber);
+  }
+
+  this._busNumber = busNumber;
+  this._peripherals = [];
+}
+
+// In this context:
+// peripheral = i2c device object (https://msdn.microsoft.com/en-us/library/windows.devices.i2c.i2cdevice.aspx)
+function peripheralSync(bus, addr) {
+  var peripheral = bus._peripherals[addr];
+
+  if (peripheral === undefined) {
+    peripheral = new i2c.WinI2c();
+    peripheral.openSync(bus._busNumber);
+    peripheral.setDevice(addr);
+    bus._peripherals[addr] = peripheral;
+  }
+  return peripheral;
+}
+
+Bus.prototype.close = function (cb) {
+  throw new Error("Not implemented");
+};
+
+Bus.prototype.closeSync = function () {
+  this._peripherals.forEach(function (peripheral) {
+    if (peripheral !== undefined) {
+      peripheral.closeSync();
+    }
+  });
+  this._peripherals = [];
+};
+
+Bus.prototype.i2cFuncs = function (cb) {
+  throw new Error("Not implemented");
+};
+
+Bus.prototype.i2cFuncsSync = function () {
+  throw new Error("Not implemented");
+};
+
+Bus.prototype.readByte = function (addr, cmd, cb) {
+  throw new Error("Not implemented");
+};
+
+Bus.prototype.readByteSync = function (addr, cmd) {
+  throw new Error("Not implemented");
+};
+
+Bus.prototype.readWord = function (addr, cmd, cb) {
+  throw new Error("Not implemented");
+};
+
+Bus.prototype.readWordSync = function (addr, cmd) {
+  throw new Error("Not implemented");
+};
+
+Bus.prototype.readBlock = function (addr, cmd, buffer, cb) {
+  throw new Error("Not implemented");
+};
+
+Bus.prototype.readBlockSync = function (addr, cmd, buffer) {
+  throw new Error("Not implemented");
+};
+
+Bus.prototype.readI2cBlock = function (addr, cmd, length, buffer, cb) {
+  throw new Error("Not implemented");
+};
+
+Bus.prototype.readI2cBlockSync = function (addr, cmd, length, buffer) {
+  return peripheralSync(this, addr).writeReadPartial(cmd, length, buffer);
+};
+
+Bus.prototype.receiveByte = function (addr, cb) {
+  throw new Error("Not implemented");
+};
+
+Bus.prototype.receiveByteSync = function (addr) {
+  throw new Error("Not implemented");
+};
+
+Bus.prototype.sendByte = function (addr, byte, cb) {
+  throw new Error("Not implemented");
+};
+
+Bus.prototype.sendByteSync = function (addr, byte) {
+  throw new Error("Not implemented");
+};
+
+Bus.prototype.writeByte = function (addr, cmd, byte, cb) {
+  throw new Error("Not implemented");
+};
+
+Bus.prototype.writeByteSync = function (addr, cmd, byte) {
+  throw new Error("Not implemented");
+};
+
+Bus.prototype.writeWord = function (addr, cmd, word, cb) {
+  throw new Error("Not implemented");
+};
+
+Bus.prototype.writeWordSync = function (addr, cmd, word) {
+  throw new Error("Not implemented");
+};
+
+Bus.prototype.writeQuickSync = function (addr, bit) {
+  throw new Error("Not implemented");
+};
+
+Bus.prototype.writeBlock = function (addr, cmd, length, buffer, cb) {
+  throw new Error("Not implemented");
+};
+
+Bus.prototype.writeBlockSync = function (addr, cmd, length, buffer) {
+  throw new Error("Not implemented");
+};
+
+Bus.prototype.writeI2cBlock = function (addr, cmd, length, buffer, cb) {
+  throw new Error("Not implemented");
+};
+
+Bus.prototype.writeI2cBlockSync = function (addr, cmd, length, buffer) {
+  throw new Error("Not implemented");
+};
+
+Bus.prototype.i2cRead = function (addr, length, buffer, cb) {
+  throw new Error("Not implemented");
+};
+
+Bus.prototype.i2cReadSync = function (addr, length, buffer) {
+  return peripheralSync(this, addr).readPartial(length, buffer);
+};
+
+Bus.prototype.i2cWrite = function (addr, length, buffer, cb) {
+  throw new Error("Not implemented");
+};
+
+Bus.prototype.i2cWriteSync = function (addr, length, buffer) {
+  return peripheralSync(this, addr).writePartial(length, buffer);
+};
+
+Bus.prototype.scan = function (cb) {
+  throw new Error("Not implemented");
+};
+
+Bus.prototype.scanSync = function () {
+  throw new Error("Not implemented");
+};
+
+module.exports.Bus = Bus;
+


### PR DESCRIPTION
I started working on Windows support for i2c-bus and this is my initial PR. The need for this came about when I started working on a project that requires i2c and runs on [Windows IoT Core](https://developer.microsoft.com/en-us/windows/iot).
In the implementation, what I did was try to match the i2c-bus functions with the methods exposed by the [i2cDevice](https://msdn.microsoft.com/library/windows/apps/windows.devices.i2c.i2cdevice.aspx) class on Windows.

There are still functions that are not implemented yet but I wanted to get this out early to get feedback as soon as possible. Note, there might be some functions that stay 'not implemented' since I can only use what i2cDevice exposes. It does however provide basic functionality to do basic read/write which was sufficient for my project. I also added an example on how to use it to read temperature from a [MCP9808](https://learn.adafruit.com/adafruit-mcp9808-precision-i2c-temperature-sensor-guide/overview) temperature sensor.

Building it does require a [change I made to gyp](https://chromium.googlesource.com/external/gyp/+/02b145a1a4f4e1c62e8bae06045caf852d9ef17f) that is not yet in the node branch. So until that change is merged to the node Github repo, building will require the following changes to gyp in your node installation:
1.Replace \<Node.js install path>\node_modules\npm\node_modules\node-gyp\gyp\pylib\gyp\generator\msvs.py with [msvs.py.txt](https://github.com/fivdi/i2c-bus/files/262154/msvs.py.txt)
2.Replace \<Node.js install path>\node_modules\npm\node_modules\node-gyp\gyp\pylib\gyp\MSVSSettings.py with [MSVSSettings.py.txt](https://github.com/fivdi/i2c-bus/files/262155/MSVSSettings.py.txt)
[Edit] **be sure to remove the .txt extensions from the files above**
