### PR TITLE
Device ID direct access function

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,8 @@ use try/catch to handle exceptions or allow them to bubble up.
   - [bus.i2cFuncsSync()](#busi2cfuncssync)
   - [bus.scan([startAddr,] [endAddr,] cb)](#busscanstartaddr-endaddr-cb)
   - [bus.scanSync([startAddr,] [endAddr])](#busscansyncstartaddr-endaddr)
+  - [bus.deviceId(addr, cb)](#busdeviceidaddr-cb)
+  - [bus.deviceIdSync(addr)](#busdeviceidsyncaddr)
 
 - Plain I2C
   - [bus.i2cRead(addr, length, buffer, cb)](#busi2creadaddr-length-buffer-cb)
@@ -354,6 +356,20 @@ Scans the I2C bus synchronously for devices. The default address range 0x03
 through 0x77 is the same as the default address range used by the `i2cdetect`
 command line tool. Returns an array of numbers where each number represents
 the I2C address of a device which was detected.
+
+### bus.deviceId(addr, cb)
+- addr - I2C device address
+- cb - completion callback
+
+Asynchronous I2C device Id.  the callback gets three arguments (err, id).
+Id is an object with `manufacturer`, `product` and if applicable a human
+readable `name` for the associated manufacturer.
+
+### bus.deviceIdSync(addr)
+- addr - I2C device address
+
+Synchronous I2C device Id.  Returns object containing `manufacturer` and `product`,
+as well as manufacturer `name` if found.
 
 ### bus.i2cRead(addr, length, buffer, cb)
 - addr - I2C device address

--- a/README.md
+++ b/README.md
@@ -361,7 +361,7 @@ the I2C address of a device which was detected.
 - addr - I2C device address
 - cb - completion callback
 
-Asynchronous I2C device Id.  the callback gets three arguments (err, id).
+Asynchronous I2C device Id.  the callback gets two arguments (err, id).
 Id is an object with `manufacturer`, `product` and if applicable a human
 readable `name` for the associated manufacturer.
 

--- a/i2c-bus.js
+++ b/i2c-bus.js
@@ -600,6 +600,19 @@ Bus.prototype.scanSync = function (startAddr, endAddr) {
   return addresses;
 };
 
+Bus.prototype.deviceId = function(addr, cb) {
+  checkAddress(addr);
+  checkCallback(cb);
+
+  peripheral(this, addr, function (err, device) {
+    if (err) {
+      return cb(err);
+    }
+
+    i2c.deviceIdAsync(device, addr, cb);
+  }.bind(this));
+}
+
 if ("win32" == process.platform) {
   Bus = require('./win-i2c-bus.js').Bus;
 }

--- a/src/deviceid.cc
+++ b/src/deviceid.cc
@@ -1,0 +1,72 @@
+#include <errno.h>
+#include <node.h>
+#include <nan.h>
+#include "./i2c-dev.h"
+#include "./deviceid.h"
+#include "./util.h"
+
+static __s32 DeviceId(int fd, __u16 address) {
+  return i2c_smbus_deviceid(fd, address);
+}
+
+class DeviceIdWorker : public I2cAsyncWorker {
+public:
+  DeviceIdWorker(Nan::Callback *callback, int fd, __u16 address)
+    : I2cAsyncWorker(callback), fd(fd), address(address) {}
+  ~DeviceIdWorker() {}
+
+  void Execute() {
+    id = DeviceId(fd, address);
+    if (id == -1) {
+      SetErrorNo(errno);
+      SetErrorSyscall("deviceId");
+    }
+  }
+
+  void HandleOKCallback() {
+    Nan::HandleScope scope;
+
+    v8::Local<v8::Value> argv[] = {
+      Nan::Null(),
+      Nan::New<v8::Integer>(id)
+    };
+
+    callback->Call(2, argv, async_resource);
+  }
+
+private:
+  int fd;
+  __u16 address;
+  __s32 id;
+};
+
+NAN_METHOD(DeviceIdAsync) {
+  if (info.Length() < 3 || !info[0]->IsInt32() || !info[1]->IsInt32() || !info[2]->IsFunction()) {
+    return Nan::ThrowError(Nan::ErrnoException(EINVAL, "deviceId",
+      "incorrect arguments passed to deviceId(int fd, int address, function cb)"));
+  }
+
+  int fd = info[0]->Int32Value();
+  __u16 address = info[1]->Int32Value();
+  Nan::Callback *callback = new Nan::Callback(info[2].As<v8::Function>());
+
+  Nan::AsyncQueueWorker(new DeviceIdWorker(callback, fd, address));
+}
+
+NAN_METHOD(DeviceIdSync) {
+  if (info.Length() < 2 || !info[0]->IsInt32() || !info[1]->IsInt32()) {
+    return Nan::ThrowError(Nan::ErrnoException(EINVAL, "deviceIdSync",
+      "incorrect arguments passed to deviceIdSync(int fd, int byte)"));
+  }
+
+  int fd = info[0]->Int32Value();
+  __u16 address = info[1]->Int32Value();
+
+  __s32 ret = DeviceId(fd, address);
+  if (ret == -1) {
+    return Nan::ThrowError(Nan::ErrnoException(errno, "deviceIdSync", ""));
+  }
+
+  info.GetReturnValue().Set(Nan::New<v8::Integer>(ret));
+}
+

--- a/src/deviceid.cc
+++ b/src/deviceid.cc
@@ -56,7 +56,7 @@ NAN_METHOD(DeviceIdAsync) {
 NAN_METHOD(DeviceIdSync) {
   if (info.Length() < 2 || !info[0]->IsInt32() || !info[1]->IsInt32()) {
     return Nan::ThrowError(Nan::ErrnoException(EINVAL, "deviceIdSync",
-      "incorrect arguments passed to deviceIdSync(int fd, int byte)"));
+      "incorrect arguments passed to deviceIdSync(int fd, int address)"));
   }
 
   int fd = info[0]->Int32Value();

--- a/src/deviceid.h
+++ b/src/deviceid.h
@@ -1,0 +1,6 @@
+#ifndef I2C_BUS_DEVICEID_H_
+#define I2C_BUS_DEVICEID_H_
+NAN_METHOD(DeviceIdAsync);
+NAN_METHOD(DeviceIdSync);
+#endif // I2C_BUS_DEVICEID_H_
+

--- a/src/i2c-dev.h
+++ b/src/i2c-dev.h
@@ -165,40 +165,40 @@ static inline __s32 i2c_smbus_access(int file, char read_write, __u8 command,
 	return ioctl(file,I2C_SMBUS,&args);
 }
 
-
+#define I2C_RESERVED_DEVICE_ID_ADDRESS 0x7C
+#define I2C_DEVICE_ID_LENGTH 3
 
 static inline __s32 i2c_smbus_deviceid(int file, __u16 address)
 {
-	char out[3];
-
+	struct i2c_rdwr_ioctl_data rdwr_data;
+	char out[I2C_DEVICE_ID_LENGTH];
 	struct i2c_msg parts[2];
 
+	// dump into char and shift up to account for R/W bit
 	char addr = address << 1;
 
-	parts[0].addr = 0xF8 >> 1;
+	// pack messages parts
+	parts[0].addr = I2C_RESERVED_DEVICE_ID_ADDRESS;
 	parts[0].flags = 0;
 	parts[0].len = 1;
 	parts[0].buf = &addr;
 
-	parts[1].addr = 0xF9 >> 1;
+	parts[1].addr = I2C_RESERVED_DEVICE_ID_ADDRESS;
 	parts[1].flags = I2C_M_RD;
-	parts[1].len = 3;
+	parts[1].len = I2C_DEVICE_ID_LENGTH;
 	parts[1].buf = out;
 
-	struct i2c_rdwr_ioctl_data rdwr_data;
 	rdwr_data.msgs = parts;
 	rdwr_data.nmsgs = 2;
 
 	__s32 ret = ioctl(file,I2C_RDWR,&rdwr_data);
-	if(ret <= 0) {
-		return ret;
+	if(ret < 0) {
+		return -1;
 	} else {
+		// shift bytes into single 24bit int
 		return out[0] << 16 | out[1] << 8 | out[2];
 	}
 }
-
-
-
 
 static inline __s32 i2c_smbus_write_quick(int file, __u8 value)
 {

--- a/src/i2c-dev.h
+++ b/src/i2c-dev.h
@@ -166,6 +166,40 @@ static inline __s32 i2c_smbus_access(int file, char read_write, __u8 command,
 }
 
 
+
+static inline __s32 i2c_smbus_deviceid(int file, __u16 address)
+{
+	char out[3];
+
+	struct i2c_msg parts[2];
+
+	char addr = address << 1;
+
+	parts[0].addr = 0xF8 >> 1;
+	parts[0].flags = 0;
+	parts[0].len = 1;
+	parts[0].buf = &addr;
+
+	parts[1].addr = 0xF9 >> 1;
+	parts[1].flags = I2C_M_RD;
+	parts[1].len = 3;
+	parts[1].buf = out;
+
+	struct i2c_rdwr_ioctl_data rdwr_data;
+	rdwr_data.msgs = parts;
+	rdwr_data.nmsgs = 2;
+
+	__s32 ret = ioctl(file,I2C_RDWR,&rdwr_data);
+	if(ret <= 0) {
+		return ret;
+	} else {
+		return out[0] << 16 | out[1] << 8 | out[2];
+	}
+}
+
+
+
+
 static inline __s32 i2c_smbus_write_quick(int file, __u8 value)
 {
 	return i2c_smbus_access(file,value,0,I2C_SMBUS_QUICK,NULL);

--- a/src/i2c.cc
+++ b/src/i2c.cc
@@ -1,6 +1,7 @@
 #include <node.h>
 #include <nan.h>
 #include "./i2cfuncs.h"
+#include "./deviceid.h"
 #include "./readbyte.h"
 #include "./readword.h"
 #include "./readblock.h"
@@ -29,6 +30,9 @@ static void ExportInt(
 NAN_MODULE_INIT(InitAll) {
   Nan::Export(target, "i2cFuncsAsync", I2cFuncsAsync);
   Nan::Export(target, "i2cFuncsSync", I2cFuncsSync);
+
+  Nan::Export(target, "deviceIdAsync", DeviceIdAsync);
+  Nan::Export(target, "deviceIdSync", DeviceIdSync);
 
   Nan::Export(target, "readByteAsync", ReadByteAsync);
   Nan::Export(target, "readByteSync", ReadByteSync);
@@ -93,6 +97,7 @@ NODE_MODULE(i2c, InitAll)
 // individually, which is what happens if they're listed in binding.gyp,
 // reduces the build time from 36s to 15s on a BBB.
 #include "./i2cfuncs.cc"
+#include "./deviceid.cc"
 #include "./readbyte.cc"
 #include "./readword.cc"
 #include "./readblock.cc"

--- a/test/deviceid.js
+++ b/test/deviceid.js
@@ -1,17 +1,16 @@
 'use strict';
 
-var i2c = require('../'),
+const i2c = require('../'),
   i2c1 = i2c.openSync(42);
 
-(function () {
-  const address = 0x50;
+const address = 0x50;
 
+(function () {
   i2c1.deviceId(address, (err, id) => {
     if(err) { console.log('error', err); }
     else console.log('id for address', '0x'+address.toString(16), id);
 
     i2c1.closeSync();
   });
-
 }());
 

--- a/test/i2c-deviceid.js
+++ b/test/i2c-deviceid.js
@@ -1,0 +1,17 @@
+'use strict';
+
+var i2c = require('../'),
+  i2c1 = i2c.openSync(42);
+
+(function () {
+  const address = 0x50;
+
+  i2c1.deviceId(address, (err, id) => {
+    if(err) { console.log('error', err); }
+    else console.log('id for address', '0x'+address.toString(16), id);
+
+    i2c1.closeSync();
+  });
+
+}());
+

--- a/test/sync-deviceid.js
+++ b/test/sync-deviceid.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const i2c = require('../'),
+  i2c1 = i2c.openSync(42);
+
+const address = 0x50;
+const invalid = 0x42;
+
+(function () {
+  const id = i2c1.deviceIdSync(address)
+  console.log('id for address', '0x'+address.toString(16), id);
+
+  //
+  try { i2c1.deviceIdSync(invalid); } catch(e) { i2c1.closeSync(); return; }
+
+  throw Error('should have exited though catch');
+}());


### PR DESCRIPTION
first pass addition of i2c_smbus_deviceid
(tested on rpi with fujitsu mb85 fram (http://www.fujitsu.com/global/documents/products/devices/semiconductor/fram/lineup/MB85RC256V-DS501-00017-5v1-E.pdf) on address 0x50, outputting 0xA510 [aka correct value for device])

top level issues / request for comment: 
- naming (Id vs ID etc)
- should deviceId be similar to i2c-func (that is, should it be named i2c_deviceId in a file name i2cdeviceid.h/cc) (software reset would follow the same pattern)
- returns full 24bit packed int.  should this be split into Manufacture / Product (in cc or js?)
- Table 4 of the spec lists "standard" manufactures, encode this some place for convenience
- move F8/F9 (7C address) magic to defines
- error checking / byte conversion etc validation
- currently missing sync call
