### PR TITLE
Made i2c-bus context-aware

### DIFF
--- a/src/i2c.cc
+++ b/src/i2c.cc
@@ -89,7 +89,11 @@ NAN_MODULE_INIT(InitAll) {
   ExportInt(target, "I2C_FUNC_SMBUS_WRITE_I2C_BLOCK", I2C_FUNC_SMBUS_WRITE_I2C_BLOCK);
 }
 
+#if NODE_MAJOR_VERSION >= 10
+NODE_MODULE_CONTEXT_AWARE(i2c, InitAll)
+#else
 NODE_MODULE(i2c, InitAll)
+#endif
 
 // Hack to speed up compilation.
 // Originally all the cc files included below were listed in the sources


### PR DESCRIPTION
Made i2c-bus context-aware with Node 10 and later releases https://nodejs.github.io/node-addon-examples/special-topics/context-awareness/. 

This also make i2c-bus work in Electron renderer process (tested in preload.js Raspberry Pi OS 11 Bullseye). 