### PR TITLE
Fixed 'Module did not self-register' error on macos using node 18.

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -5,7 +5,7 @@
       "<!(node -e \"require('nan')\")"
     ],
     "conditions": [[
-      'OS == "linux"', {
+      'OS == "linux" or OS == "mac"', {
         "sources": [
          "./src/i2c.cc"
         ],
@@ -21,4 +21,3 @@
     ]
   }]
 }
-

--- a/src/i2c-dev.h
+++ b/src/i2c-dev.h
@@ -23,7 +23,16 @@
 #ifndef _LINUX_I2C_DEV_H
 #define _LINUX_I2C_DEV_H
 
+#ifdef __linux__
 #include <linux/types.h>
+#else
+# include <stdint.h>
+typedef int32_t __s32;
+typedef uint8_t __u8;
+typedef uint16_t __u16;
+typedef uint32_t __u32;
+#endif
+
 #include <sys/ioctl.h>
 #include <stddef.h>
 


### PR DESCRIPTION
I was working on a new project using node 18 on my mac dev machine and got an error while trying to run said project.
Error was `Error: Module did not self-register: '/Volumes/Development/projects/pandore/piadvanced/node_modules/i2c-bus/build/Release/i2c.node'.`
It used to work fine on node 14.
Tried different things but what worked was actually getting the native bindings to compile and be declared properly on macos.
Might be useful to anyone working on macs.